### PR TITLE
Disable fixreads as due to problem on Nvidia GPUs

### DIFF
--- a/bin/kfusion
+++ b/bin/kfusion
@@ -2,6 +2,6 @@
 
 JARS=$(echo ${KFUSION_ROOT}/target/*.jar | tr ' ' ':')
 
-JFLAGS="-Xms28G -Xmx28G -Dtornado.kernels.coarsener=False -Dlog4j.configurationFile=${KFUSION_ROOT}/conf/log4j2.xml"
+JFLAGS="-Xms28G -Xmx28G -Dtornado.kernels.coarsener=False -Dtornado.enable.fix.reads=False -Dlog4j.configurationFile=${KFUSION_ROOT}/conf/log4j2.xml"
 
 CLASSPATH=${CLASSPATH}:${JARS} tornado ${JFLAGS} $@


### PR DESCRIPTION
This PR adds one extra Tornado flag (`-Dtornado.enable.fix.reads=False`) that disables the Fix-Reads for OpenCL. 
This flag when running with PTX is ignored. This is a termparary fix to enable Kfusion running on Nvidia GPUs with OpenCL. Further investigation is foreseen in the future.

I have tested both OpenCL and PTX backends with the PR `106` in the TornadoVM repository.