### PR TITLE
Update TornadoVM version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,13 +83,13 @@
      <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-api</artifactId>
-         <version>0.15.2-dev</version>
+         <version>0.16-dev</version>
      </dependency>
    
      <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-matrices</artifactId>
-         <version>0.15.2-dev</version>
+         <version>0.16-dev</version>
      </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR updates the version of TornadoVM dependency to be the same version with the latest version in TornadoVM `master` (which is the default branch used in the README file).