### PR TITLE
[fix] Update API functions for TornadoVM v1.0.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,13 +94,13 @@
      <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-api</artifactId>
-         <version>1.0.1-dev</version>
+         <version>1.0.4-dev</version>
      </dependency>
    
      <dependency>
          <groupId>tornado</groupId>
          <artifactId>tornado-matrices</artifactId>
-         <version>1.0.1-dev</version>
+         <version>1.0.4-dev</version>
      </dependency>
 
         <dependency>

--- a/src/main/java/kfusion/tornado/common/TornadoModel.java
+++ b/src/main/java/kfusion/tornado/common/TornadoModel.java
@@ -89,6 +89,6 @@ public class TornadoModel extends KfusionConfig {
 	public void reset() {
 		super.reset();
 		useTornado = Boolean.parseBoolean(settings.getProperty("kfusion.tornado.enable", "False"));
-		tornadoDevice = TornadoRuntime.getTornadoRuntime().getDriver(getPlatformIndex()).getDevice(getDeviceIndex());
+		tornadoDevice = TornadoRuntime.getTornadoRuntime().getBackend(getPlatformIndex()).getDevice(getDeviceIndex());
 	}
 }

--- a/src/main/java/kfusion/tornado/pipeline/TornadoBenchmarkPipeline.java
+++ b/src/main/java/kfusion/tornado/pipeline/TornadoBenchmarkPipeline.java
@@ -263,7 +263,7 @@ public class TornadoBenchmarkPipeline extends AbstractPipeline<TornadoModel> {
 				final int numWgs = Math.min(roundToWgs(numElements / cus, 128), maxwgs);
 
 				trackingPyramidGraphs[i].prebuiltTask("customReduce" + i,
-									tornadoDevice.getDeviceContext().needsBump() ? "optMapReduceBump" : "optMapReduce",
+									"optMapReduce",
 									"./opencl/optMapReduce.cl",
 									new Object[]{icpResultIntermediate1, result, result.X(), result.Y()},
 									new Access[]{Access.WRITE_ONLY, Access.READ_ONLY, Access.READ_ONLY, Access.READ_ONLY},

--- a/src/main/java/kfusion/tornado/pipeline/TornadoBilateralFilterPipeline.java
+++ b/src/main/java/kfusion/tornado/pipeline/TornadoBilateralFilterPipeline.java
@@ -61,7 +61,7 @@ public class TornadoBilateralFilterPipeline<T extends TornadoModel> extends Abst
         /*
          * Cleanup after previous configurations
          */
-        oclDevice.reset();
+        oclDevice.clean();
 
 
         preprocessingGraph = new TaskGraph("pp")

--- a/src/main/java/kfusion/tornado/pipeline/TornadoOpenGLPipeline.java
+++ b/src/main/java/kfusion/tornado/pipeline/TornadoOpenGLPipeline.java
@@ -90,7 +90,7 @@ public class TornadoOpenGLPipeline<T extends TornadoModel> extends AbstractOpenG
         /*
          * Cleanup after previous configurations
          */
-        acceleratorDevice.reset();
+        acceleratorDevice.clean();
 
         pyramidPose = new Matrix4x4Float();
         pyramidDepths[0] = filteredDepthImage;

--- a/src/main/java/kfusion/tornado/ui/TornadoConfigPanel.java
+++ b/src/main/java/kfusion/tornado/ui/TornadoConfigPanel.java
@@ -37,7 +37,7 @@ import javax.swing.JPanel;
 import javax.swing.border.EtchedBorder;
 
 import kfusion.tornado.common.TornadoModel;
-import uk.ac.manchester.tornado.api.TornadoDriver;
+import uk.ac.manchester.tornado.api.TornadoBackend;
 import uk.ac.manchester.tornado.api.common.TornadoDevice;
 import uk.ac.manchester.tornado.api.runtime.TornadoRuntime;
 
@@ -53,7 +53,7 @@ public class TornadoConfigPanel extends JPanel implements ActionListener {
 
     private TornadoDevice[] getAllTornadoDevices() {
         final TornadoDevice[] devices;
-        TornadoDriver driver = TornadoRuntime.getTornadoRuntime().getDriver(0);
+        TornadoBackend driver = TornadoRuntime.getTornadoRuntime().getBackend(0);
         final List<TornadoDevice> tmpDevices = new ArrayList<>();
         if (driver != null) {
             for (int devIndex = 0; devIndex < driver.getDeviceCount(); devIndex++) {


### PR DESCRIPTION
This PR includes the following changes:

- Update the classes with the refactored API functions (and the deprecated `needsBump()` method).
- Update the dependency version in the pom file.

I tested it with the TornadoVM OpenCL and PTX backends on my `NVIDIA RTX A2000 8GB Laptop GPU`.

**How to test?**
```bash
mvn clean install
kfusion kfusion.tornado.Benchmark conf/bm-traj2.settings
```