### PR TITLE
[hotfix] Replace refactored method to build kfusion

### DIFF
--- a/src/main/java/kfusion/tornado/ui/TornadoConfigPanel.java
+++ b/src/main/java/kfusion/tornado/ui/TornadoConfigPanel.java
@@ -56,7 +56,7 @@ public class TornadoConfigPanel extends JPanel implements ActionListener {
         TornadoBackend driver = TornadoRuntime.getTornadoRuntime().getBackend(0);
         final List<TornadoDevice> tmpDevices = new ArrayList<>();
         if (driver != null) {
-            for (int devIndex = 0; devIndex < driver.getDeviceCount(); devIndex++) {
+            for (int devIndex = 0; devIndex < driver.getBackendCounter(); devIndex++) {
                 final TornadoDevice device = driver.getDevice(devIndex);
                 tmpDevices.add(device);
             }


### PR DESCRIPTION
This PR makes a minor change regarding a refactored method in the `TornadoBackend` class.

the `getDeviceCount` is refactored to `getBackendCounter`, as shown in this [commit point](https://github.com/beehive-lab/TornadoVM/commit/89d96af4f8ef5caff9448ba4280d607db6defc6a).

To build kfusion try:
```bash
mvn clean install
```