### PR TITLE
[test] Added runtime parameters to select backend type that is used

### DIFF
--- a/scripts/runOnlyOpenCL.sh
+++ b/scripts/runOnlyOpenCL.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "kfusion  kfusion.tornado.Benchmark conf/bm-traj2.settings "
+
+JARS=$(echo ${KFUSION_ROOT}/target/*.jar | tr ' ' ':')
+
+JFLAGS="-Xms4G -Xmx4G -Dtornado.kernels.coarsener=False -Dtornado.enable.fix.reads=False -Dlog4j.configurationFile=${KFUSION_ROOT}/conf/log4j2.xml -Dtornado.benchmarking=False -Dtornado.profiler=False -Dtornado.log.profiler=False -Dtornado.opencl.priority=100"
+
+CLASSPATH=${CLASSPATH}:${JARS} tornado --jvm="${JFLAGS}" kfusion.tornado.Benchmark --params="conf/bm-traj2.settings" 
+
+#kfusion -Xms4g -Xmx4g -Dtornado.benchmarking=False -Dtornado.profiler=False -Dtornado.log.profiler=False kfusion.tornado.Benchmark conf/bm-traj2.settings 
+

--- a/scripts/runOnlyPTX.sh
+++ b/scripts/runOnlyPTX.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+echo "kfusion  kfusion.tornado.Benchmark conf/bm-traj2.settings "
+
+JARS=$(echo ${KFUSION_ROOT}/target/*.jar | tr ' ' ':')
+
+JFLAGS="-Xms4G -Xmx4G -Dtornado.kernels.coarsener=False -Dtornado.enable.fix.reads=False -Dlog4j.configurationFile=${KFUSION_ROOT}/conf/log4j2.xml -Dtornado.benchmarking=False -Dtornado.profiler=False -Dtornado.log.profiler=False -Dtornado.ptx.priority=100"
+
+CLASSPATH=${CLASSPATH}:${JARS} tornado --jvm="${JFLAGS}" kfusion.tornado.Benchmark --params="conf/bm-traj2.settings" 
+
+#kfusion -Xms4g -Xmx4g -Dtornado.benchmarking=False -Dtornado.profiler=False -Dtornado.log.profiler=False kfusion.tornado.Benchmark conf/bm-traj2.settings 
+


### PR DESCRIPTION
In this PR, I added two copies of the `scripts/run.sh` script that runs kfusion with TornadoVM in console mode for the regression tests. The change is that I use the priority flag that is passed at runtime to select the backend that is used.

`-Dtornado.opencl.priority=100` and `-Dtornado.ptx.priority=100`


**Description of the problem:**
The problem is that when TornadoVM is built with all backends (OpenCL, PTX and SPIR-V) the default backend is SPIR-V, and therefore the current kfusion running script is failing in Jenkins. Additionally, note that the `kfusion.tornado.backend` parameter in the `conf/kfusion.settings` file seems to have been deprecated as it is not used any more.

The suggestion here aims to fix the Jenkins pipeline.